### PR TITLE
Fix password generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update \
         samba \
         bash-completion \
         procps \
+        whois \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
`mkpasswd` is not part of the base image, nor any dependency.

It can be used from e.g. `whois` package, see https://packages.debian.org/search?searchon=contents&keywords=mkpasswd&mode=exactfilename&suite=bookworm&arch=any

Related #6 