### PR TITLE
Support for certain Brother laser printers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update \
         dbus \
         colord \
         printer-driver-all \
+        printer-driver-brlaser \
         printer-driver-gutenprint \
         openprinting-ppds \
         hpijs-ppds \


### PR DESCRIPTION
Install the "printer-driver-brlaser" package for printing with:

-     DCP-1510
-     DCP-1602
-     DCP-7030
-     DCP-7040
-     DCP-7055
-     DCP-7055W
-     DCP-7060D
-     DCP-7065DN
-     DCP-7080
-     DCP-L2500D
-     DCP-L2540DW
-     HL-1110 series
-     HL-1200 series
-     HL-L2300D series
-     HL-L2320D series
-     HL-L2340D series
-     HL-L2360D series
-     MFC-1910W
-     MFC-7240
-     MFC-7360N
-     MFC-7365DN
-     MFC-7840W
-     MFC-L2710DW
-     Lenovo M7605D 

See: https://wiki.debian.org/Brother for more info