### PR TITLE
Add splix driver to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update \
         dbus \
         colord \
         printer-driver-all \
+        printer-driver-splix \
         printer-driver-gutenprint \
         openprinting-ppds \
         hpijs-ppds \


### PR DESCRIPTION
Solves #3

This fixes the issue `Idle - "File "/usr/lib/cups/filter/rastertospl" not available: No such file or directory"` for me.

Particularly for an ML-1860, in my case in combination with this PPD https://github.com/rshev/SpliXextras/