### PR TITLE
Add EPSON escpr drivers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update \
         hp-ppd  \
         hplip \
         printer-driver-foo2zjs \
+        printer-driver-escpr \
         cups-pdf \
         gnupg2 \
         lsb-release \

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
-  "name": "Home Assistant CUPS + Airprint Add-On repository",
-  "url": "https://github.com/zajac-grzegorz/homeassistant-addon-cups-airprint",
+  "name": "Home Assistant CUPS + Airprint Add-On repository fjfricke Test",
+  "url": "https://github.com/fjfricke/homeassistant-addon-cups-airprint",
   "maintainer": "Grzegorz Zajac"
 }

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
-  "name": "Home Assistant CUPS + Airprint Add-On repository fjfricke Test",
-  "url": "https://github.com/fjfricke/homeassistant-addon-cups-airprint",
+  "name": "Home Assistant CUPS + Airprint Add-On repository",
+  "url": "https://github.com/zajac-grzegorz/homeassistant-addon-cups-airprint",
   "maintainer": "Grzegorz Zajac"
 }


### PR DESCRIPTION
Adds printers for EPSON that are not part of the standard printer library. Also fixes the issue that adding .ppd files manually for EPSON printers that are not part of this library yet (e.g. new printers like the XP-2200) fails.