### PR TITLE
Update Debian Base and add HP drivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+## v1.5
+
+- Update Debian Base to 7.6.2
+- Add HP drivers (printer-driver-hpcups)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/hassio-addons/debian-base:7.6.2
 
-LABEL io.hass.version="1.0" io.hass.type="addon" io.hass.arch="aarch64|amd64"
+LABEL io.hass.version="1.5" io.hass.type="addon" io.hass.arch="aarch64|amd64"
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update \
         hpijs-ppds \
         hp-ppd  \
         hplip \
+        printer-driver-hpcups \
         printer-driver-foo2zjs \
         cups-pdf \
         gnupg2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/hassio-addons/debian-base:7.1.0
+FROM ghcr.io/hassio-addons/debian-base:7.6.2
 
 LABEL io.hass.version="1.0" io.hass.type="addon" io.hass.arch="aarch64|amd64"
 

--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ CUPS administrator login: **print**, password: **print** (can be changed in the 
 
 Configuration data is stored in **/data/cups** folder
 
-[![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fzajac-grzegorz%2Fhomeassistant-addon-cups-airprint)
+[![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https://github.com/mastria/homeassistant-addon-cups-airprint)

--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ CUPS administrator login: **print**, password: **print** (can be changed in the 
 
 Configuration data is stored in **/data/cups** folder
 
-[![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https://github.com/mastria/homeassistant-addon-cups-airprint)
+[![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fzajac-grzegorz%2Fhomeassistant-addon-cups-airprint)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # homeassistant addon cups airprint
 CUPS addon with working Avahi in reflector mode 
 
-Tested with Home Assistant version **2023.9**
+Tested with Home Assistant version **2024.12.2**
 
 CUPS administrator login: **print**, password: **print** (can be changed in the Dockerfile)
 

--- a/build.yaml
+++ b/build.yaml
@@ -1,3 +1,3 @@
 build_from:
-  aarch64: ghcr.io/hassio-addons/debian-base:7.1.0
-  amd64: ghcr.io/hassio-addons/debian-base:7.1.0
+  aarch64: ghcr.io/hassio-addons/debian-base:7.6.2
+  amd64: ghcr.io/hassio-addons/debian-base:7.6.2

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 name: CUPS
-version: "1.0"
+version: "1.5"
 slug: cupsik
 description: A CUPS print server with working AirPrint
 arch:

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
   "name": "Home Assistant CUPS + Airprint Add-On repository",
-  "url": "https://github.com/mastria/homeassistant-addon-cups-airprint",
-  "maintainer": "Guilherme Mastria"
+  "url": "https://github.com/zajac-grzegorz/homeassistant-addon-cups-airprint",
+  "maintainer": "Grzegorz Zajac"
 }

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
   "name": "Home Assistant CUPS + Airprint Add-On repository",
-  "url": "https://github.com/zajac-grzegorz/homeassistant-addon-cups-airprint",
-  "maintainer": "Grzegorz Zajac"
+  "url": "https://github.com/mastria/homeassistant-addon-cups-airprint",
+  "maintainer": "Guilherme Mastria"
 }


### PR DESCRIPTION
- Update Debian Base to 7.6.2
- Add HP drivers (printer-driver-hpcups) to work with [LaserJet M1120](https://support.hp.com/us-en/product/details/hp-laserjet-m1120-multifunction-printer-series/3447595)
- Tested with Home Assistant version **2024.12.2**